### PR TITLE
Remove configuration options from entity attributes

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -48,7 +48,7 @@ from homeassistant.util.dt import utcnow as dt_utcnow, as_local
 
 from datetime import datetime, timedelta
 
-VERSION = '1.0.5'
+VERSION = '1.0.6'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/circadian_lighting/sensor.py
+++ b/custom_components/circadian_lighting/sensor.py
@@ -45,7 +45,10 @@ class CircadianSensor(Entity):
         self._unit_of_measurement = '%'
         self._icon = ICON
         self._hs_color = self._cl.data['hs_color']
-        self._attributes = self._cl.data
+        self._attributes = {}
+        self._attributes['colortemp'] = self._cl.data['colortemp']
+        self._attributes['rgb_color'] = self._cl.data['rgb_color']
+        self._attributes['xy_color'] = self._cl.data['xy_color']
 
         """Register callbacks."""
         dispatcher_connect(hass, CIRCADIAN_LIGHTING_UPDATE_TOPIC, self.update_sensor)
@@ -82,7 +85,7 @@ class CircadianSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the attributes of the sensor."""
-        return dict((k,str(v) if isinstance(v, datetime.time) or isinstance(v, datetime.timedelta) else v) for k,v in self._attributes.items())
+        return self._attributes
 
     def update(self):
         """Fetch new state data for the sensor.
@@ -95,5 +98,7 @@ class CircadianSensor(Entity):
         if self._cl.data is not None:
             self._state = self._cl.data['percent']
             self._hs_color = self._cl.data['hs_color']
-            self._attributes = self._cl.data
+            self._attributes['colortemp'] = self._cl.data['colortemp']
+            self._attributes['rgb_color'] = self._cl.data['rgb_color']
+            self._attributes['xy_color'] = self._cl.data['xy_color']
             _LOGGER.debug("Circadian Lighting Sensor Updated")

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,7 +1,7 @@
 {
     "circadian_lighting": {
-        "updated_at": "2019-06-01",
-        "version": "1.0.5",
+        "updated_at": "2019-06-14",
+        "version": "1.0.6",
         "local_location": "/custom_components/circadian_lighting/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/claytonjn/hass-circadian_lighting/master/custom_components/circadian_lighting/__init__.py",
         "visit_repo": "https://github.com/claytonjn/hass-circadian_lighting",


### PR DESCRIPTION
The biggest concern is that apparently any device_class with longitude, latitude, and elevation will show up on the HA map (not just device_tracker). In general, however, configuration options in attributes is extraneous and the community voted to remove them (https://community.home-assistant.io/t/circadian-lighting-custom-component/61246/355)