### PR TITLE
Fixed services to conform to Home Assistant specs

### DIFF
--- a/custom_components/circadian_lighting/services.yaml
+++ b/custom_components/circadian_lighting/services.yaml
@@ -1,3 +1,2 @@
 values_update:
   description: Updates values for Circadian Lighting.
-  fields:


### PR DESCRIPTION
Since `values_update` does not contain any fields, it should not list the keyword in the services.yaml.