### PR TITLE
Disable morning/evening brightness adjust

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -279,6 +279,16 @@ class CircadianLighting(object):
         _LOGGER.debug("a: " + str(a))
         _LOGGER.debug("percentage: " + str(percentage))
 
+        if 'percent' in self.data:
+            if percentage > self.data['percent']:
+                self.data['direction'] = 1
+            elif percentage < self.data['percent']:
+                self.data['direction'] = -1
+            else:
+                self.data['direction'] = 0
+        else:
+            self.data['direction'] = 0
+
         return percentage
 
     def calc_colortemp(self):

--- a/custom_components/circadian_lighting/sensor.py
+++ b/custom_components/circadian_lighting/sensor.py
@@ -49,6 +49,7 @@ class CircadianSensor(Entity):
         self._attributes['colortemp'] = self._cl.data['colortemp']
         self._attributes['rgb_color'] = self._cl.data['rgb_color']
         self._attributes['xy_color'] = self._cl.data['xy_color']
+        self._attributes['direction'] = self._cl.data['direction']
 
         """Register callbacks."""
         dispatcher_connect(hass, CIRCADIAN_LIGHTING_UPDATE_TOPIC, self.update_sensor)
@@ -101,4 +102,5 @@ class CircadianSensor(Entity):
             self._attributes['colortemp'] = self._cl.data['colortemp']
             self._attributes['rgb_color'] = self._cl.data['rgb_color']
             self._attributes['xy_color'] = self._cl.data['xy_color']
+            self._attributes['direction'] = self._cl.data['direction']
             _LOGGER.debug("Circadian Lighting Sensor Updated")


### PR DESCRIPTION
Hi!

This is a pull request that is inspired by the existing CONF_DISABLE_BRIGHTNESS_ADJUST configuration, but split into morning & evening. The use case is that I am using a wake up light that configures brightness separately from the circadian lightning, but I do not want to miss out on the evening functionality by setting CONF_DISABLE_BRIGHTNESS_ADJUST to true. Instead, this PR allows for disabling the brightness adjust in the morning (or evening) while maintaining the brightness adjust for the other part of the day, as well as maintaining the color temperature from circadian while using a separate wake up light.

Feel free to ask if anything is unclear, and thank you for a well working and highly appreciated integration!