### PR TITLE
More accurately convert colortemp to xy and hs

### DIFF
--- a/custom_components/circadian_lighting/manifest.json
+++ b/custom_components/circadian_lighting/manifest.json
@@ -4,5 +4,8 @@
   "documentation": "https://github.com/claytonjn/hass-circadian_lighting",
   "dependencies": [],
   "codeowners": ["@claytonjn"],
-  "requirements": ["timezonefinder==4.2.0"]
+  "requirements": [
+    "timezonefinder==4.2.0",
+    "colour-science"
+  ]
 }

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -9,6 +9,7 @@ import logging
 from custom_components.circadian_lighting import DOMAIN, CIRCADIAN_LIGHTING_UPDATE_TOPIC, DATA_CIRCADIAN_LIGHTING
 
 import voluptuous as vol
+import colour
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_connect
@@ -235,7 +236,11 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
             return color_temperature_to_rgb(self._cl.data['colortemp'])
 
     def calc_xy(self):
-        return color_RGB_to_xy(*self.calc_rgb())
+        if self.is_sleep():
+            _LOGGER.debug(self._name + " in Sleep mode")
+            return list(colour.temperature.CCT_to_xy_CIE_D(self._sleep_colortemp))
+        else:
+            return list(colour.temperature.CCT_to_xy_CIE_D(self._cl.data['colortemp']))
 
     def calc_hs(self):
         return color_xy_to_hs(*self.calc_xy())


### PR DESCRIPTION
The current color conversion from color temperature to rgb distorts colors. For instance during the day whiter colors get shifted slightly towards magenta, while in the evening warmer color temperatures shift more towards red. This is a problem when using led bulbs that don't directly support color temperature but can for instance be set in xy or hs. This PR uses a more accurate conversion for color temperature by using the functions provided by the [colour-science](https://github.com/colour-science/colour) package.

![color_diffs](https://user-images.githubusercontent.com/7020332/115426048-73b6ed80-a200-11eb-921a-634818517bee.jpg)

This photo shows the effect of this PR. The light bulbs in the three rooms in the picture (left, middle, and right) have all been set with the hass-circardian_lighting component.

The room on the right has a light that directly accepts color temperatures as a setting. The color of the middle room comes from setting a RGB light with the current version of this repo (without this PR). On the room on the left we have again a RGB light, but set in xy with this PR applied. As it can be seen the color generated with this PR (room on the left) more accurately resembles the light generated by the native color temperature light bulb (room on the right).
