### PR TITLE
[DRAFT] Adding a methode to update hue scenes

### DIFF
--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -3,6 +3,8 @@ Circadian Lighting Switch for Home-Assistant.
 """
 
 import asyncio
+import aiohttp
+from aiohue.discovery import discover_nupnp
 import logging
 from itertools import repeat
 
@@ -59,6 +61,9 @@ CONF_DISABLE_ENTITY = "disable_entity"
 CONF_DISABLE_STATE = "disable_state"
 CONF_INITIAL_TRANSITION, DEFAULT_INITIAL_TRANSITION = "initial_transition", 1
 CONF_ONLY_ONCE = "only_once"
+CONF_HUE_USERNAME = "hue_username"
+CONF_HUE_KEYWORD  = "hue_keyword"
+CONF_HUE_BRIDGE   = "hue_bridge"
 
 PLATFORM_SCHEMA = vol.Schema(
     {
@@ -89,6 +94,9 @@ PLATFORM_SCHEMA = vol.Schema(
             CONF_INITIAL_TRANSITION, default=DEFAULT_INITIAL_TRANSITION
         ): VALID_TRANSITION,
         vol.Optional(CONF_ONLY_ONCE, default=False): cv.boolean,
+        vol.Optional(CONF_HUE_USERNAME): cv.string,
+        vol.Optional(CONF_HUE_KEYWORD): cv.string,
+        vol.Optional(CONF_HUE_BRIDGE): cv.string,
     }
 )
 
@@ -116,6 +124,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             disable_state=config.get(CONF_DISABLE_STATE),
             initial_transition=config.get(CONF_INITIAL_TRANSITION),
             only_once=config.get(CONF_ONLY_ONCE),
+            hue_username=config.get(CONF_HUE_USERNAME),
+            hue_keyword=config.get(CONF_HUE_KEYWORD),
+            hue_bridge=config.get(CONF_HUE_BRIDGE),
         )
         add_devices([switch])
 
@@ -180,6 +191,9 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         disable_state,
         initial_transition,
         only_once,
+        hue_username,
+        hue_keyword,
+        hue_bridge
     ):
         """Initialize the Circadian Lighting switch."""
         self.hass = hass
@@ -201,6 +215,9 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         self._disable_state = disable_state
         self._initial_transition = initial_transition
         self._only_once = only_once
+        self._hue_username = hue_username
+        self._hue_keyword = hue_keyword
+        self._hue_bridge = hue_bridge
         self._lights_types = dict(zip(lights_ct, repeat("ct")))
         self._lights_types.update(zip(lights_rgb, repeat("rgb")))
         self._lights_types.update(zip(lights_xy, repeat("xy")))
@@ -321,11 +338,29 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         self._hs_color = self._calc_hs()
         self._brightness = self._calc_brightness()
         await self._adjust_lights(lights or self._lights, transition)
+        if self._hue_username is not None:
+            async with aiohttp.ClientSession() as session:
+                await self.update_hue_run(session)
 
     async def _force_update_switch(self, lights=None):
         return await self._update_switch(
             lights, transition=self._initial_transition, force=True
         )
+    
+    async def update_hue_run(self,websession):
+        bridges = await discover_nupnp(websession)
+
+        bridge = bridges[0]
+        bridge.username = self._hue_username
+
+        await bridge.initialize()
+        for id in bridge.scenes:
+            scene = bridge.scenes[id]
+            if self._hue_keyword in scene.name:
+                color_temp = self._calc_ct()
+                lightstates = await scene.lightstates
+                for light_id in scene.lights:
+                    await scene.set_lightstate(id=light_id,on=lightstates[light_id]["on"],bri=self._brightness,ct=color_temp)
 
     def _is_disabled(self):
         return (


### PR DESCRIPTION
I was bored to create a rest command for each hue scene I had to update and I was needing to update the command in case I add a light, thus I decided to integrate it into circadian lighting, in my setup it does work hard coded inside `init.py` but I drafted this PR to make it parametrable.

That should update all scenes that contain the keyword in the name, bridge option is intended to be optional (as it can be discovered) and username is maybe retrival from the hue official integration (not sure)

```
Depends on the home-assistant-libs/aiohue#67 PR
This will update all philips hue scenes that contain a defined keyword to match circadian lighting, this will keep the on/off state of a scene, therefore multiple scenes can be created to switch between differents lights with a philips remote

Note : this is not fully implemented, neither debuged
```