### PR TITLE
Wait for astral to have attribute 'location' before using it

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -30,6 +30,7 @@ Technical notes: I had to make a lot of assumptions when writing this app
 import bisect
 import logging
 from datetime import timedelta
+from time import sleep
 
 import astral
 import voluptuous as vol
@@ -201,6 +202,10 @@ class CircadianLighting:
             solar_midnight = sunset + ((sunrise + timedelta(days=1)) - sunset) / 2
         else:
             try:
+              tries = 0
+              while (not hasattr(astral, 'location')) and tries < 30:
+                  tries += 1
+                  sleep(1)
               location = astral.location.Location()
             except AttributeError:
               location = astral.Location()


### PR DESCRIPTION
Sometimes while initializing the component the `astral` module doesn't have the `location` attribute yet when the component tries to use it, cause bugs like  #148, #149 and #175.

This PR implements a loop that causes initialization to wait another second if the attribute isn't available yet. If it still isn't available after 30 seconds we let the initialization continue and crash, like before.

I have been running with a simpler version of the fix (a single 10 second sleep) for months, which has completely fixed the issue for me, but this version is a bit more clever to avoid waiting longer than necessary while also being more resilient in case longer is needed.

Closes #149, closes #175.