### PR TITLE
handle Astral v2.2

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -57,6 +57,7 @@ from homeassistant.util.color import (
     color_temperature_to_rgb,
     color_xy_to_hs,
 )
+from homeassistant.helpers.sun import get_astral_location
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -204,10 +205,13 @@ class CircadianLighting:
                 _LOGGER.debug("Astral version: " + astral.__version__)
             except Exception as e:
                 _LOGGER.error(e)
-            try:
-              location = astral.location.Location()
-            except AttributeError:
-              location = astral.Location()
+            _loc = get_astral_location(self.hass)
+            if isinstance(_loc, tuple):
+                # Astral v2.2
+                location, _ = _loc
+            else:
+                # Astral v1
+                location = _loc
             location.name = "name"
             location.region = "region"
             location.latitude = self._latitude

--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -31,7 +31,6 @@ import bisect
 import logging
 from datetime import timedelta
 
-import astral
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
@@ -201,10 +200,6 @@ class CircadianLighting:
             solar_noon = sunrise + (sunset - sunrise) / 2
             solar_midnight = sunset + ((sunrise + timedelta(days=1)) - sunset) / 2
         else:
-            try:
-                _LOGGER.debug("Astral version: " + astral.__version__)
-            except Exception as e:
-                _LOGGER.error(e)
             _loc = get_astral_location(self.hass)
             if isinstance(_loc, tuple):
                 # Astral v2.2

--- a/custom_components/circadian_lighting/manifest.json
+++ b/custom_components/circadian_lighting/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "circadian_lighting",
   "name": "Circadian Lighting",
-  "version": "2.0.7-beta",
+  "version": "2.0.8-beta",
   "documentation": "https://github.com/claytonjn/hass-circadian_lighting",
   "issue_tracker": "https://github.com/claytonjn/hass-circadian_lighting/issues",
   "dependencies": ["sensor","switch"],


### PR DESCRIPTION
Fix Astral v2.2 compatibility. 

Code copied from https://github.com/basnijholt/adaptive-lighting/blob/9e8c199c619ac25111f02a2ee7f0ed252ccffbb3/custom_components/adaptive_lighting/switch.py

Fixes #188 