### PR TITLE
Fix the ability to specify sunrise/sunset time manually

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -185,7 +185,7 @@ class CircadianLighting:
 
     async def _async_replace_time(self, date, key):
         other_date = self._manual_sunrise if key == "sunrise" else self._manual_sunset
-        return await self.hass.async_add_executor_job(date.replace,
+        return date.replace(
             hour=other_date.hour,
             minute=other_date.minute,
             second=other_date.second,


### PR DESCRIPTION
Background: https://github.com/claytonjn/hass-circadian_lighting/issues/204#issuecomment-1242364207

> - Since 2.1.0-beta the integration [made a lot of methods asynchronous](https://github.com/claytonjn/hass-circadian_lighting/commit/19df0f8a616cdd056981a20453f624a85884d86d#diff-22a035a563bebffed04d9409d097718abff0f630e8b7cf26e8910608d01e533bR188) (if I'm interpreting this right) and replaced a plain call to `date.replace` with `async_add_executor_job` that should've called the same method asynchronously with the same arguments
> - [The `async_add_executor_job`](https://github.com/home-assistant/core/blob/61ff1b786bf6d6341b7c40895fa478058532223f/homeassistant/core.py#L512-L515), as it exists right now, does not accept any keyword arguments, and this blows up on the above call that has them
> 
> So — since 2.1.0-beta manually specifying sunset/sunrise times should've been completely broken. I think that adds up with what I've experienced 🤔
> 
> Replacing components of a date doesn't sound like something that should require any asynchrony, as it's an operation entirely for a tiny amount of CPU and RAM, with no I/O. So the fix, I suppose, is to turn that particular bit back to synchronous?

Fixes #204 — tested by performing the same change in my local installation of 2.1.2 and restarting Home Assistant (2022.9.1) with the following configuration:

```yaml
circadian_lighting:
  min_colortemp: 1700
  max_colortemp: 6500
  transition: 10
  sunrise_time: "04:00:00"
  sunset_time: "21:00:00"
```

> ⚠ While I have experience in other languages, I'm a relative newcomer to Python and may be overlooking something glaringly obvious.