### PR TITLE
Fix an issue with calculating solar noon and midnight in some configurations

### DIFF
--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -198,6 +198,19 @@ class CircadianLighting:
             sunset = await self._async_replace_time(date, "sunset")
             solar_noon = sunrise + (sunset - sunrise) / 2
             solar_midnight = sunset + ((sunrise + timedelta(days=1)) - sunset) / 2
+            
+            # The replacement algorithm above keeps the current day,
+            # but changes time to sunrise/sunset. Unfortunately, it
+            # does not account for timezones. For people who's sunset
+            # is after 23:59 UTC (i.e. 01:30), the two events are out
+            # of order in the day.
+            
+            # Fortunately, the nature of the math means that, if
+            # sunrise and sunset are swapped, solar noon and solar
+            # midnight simply end up swapped as well. So we can
+            # simply swap them back if we need to.
+            if (sunset < sunrise):  # Out-of-order sunrise check
+                solar_noon, solar_midnight = solar_midnight, solar_noon
         else:
             _loc = await self.hass.async_add_executor_job(get_astral_location, self.hass)
             if isinstance(_loc, tuple):

--- a/custom_components/circadian_lighting/manifest.json
+++ b/custom_components/circadian_lighting/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "circadian_lighting",
   "name": "Circadian Lighting",
-  "version": "2.1.3-beta",
+  "version": "2.1.3",
   "documentation": "https://github.com/claytonjn/hass-circadian_lighting",
   "issue_tracker": "https://github.com/claytonjn/hass-circadian_lighting/issues",
   "dependencies": ["sensor","switch"],


### PR DESCRIPTION
Currently, incorrect values are calculated in configurations where sunset is before sunrise in the day (e.g. day from 14:00 to 02:00 UTC). This pull request fixes this problem.