### PR TITLE
Support RGBW LED strips with dedicated cold white LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Switch configuration variables:
 * **name** (_Optional_): The name to use when displaying this switch.
 * **lights_ct** (_Optional_): array: List of light entities which should be set in mireds.
 * **lights_rgb** (_Optional_): array: List of light entities which should be set in RGB.
+* **lights_rgbw** (_Optional_): array: List of light entities which should be set in RGBW.
 * **lights_xy** (_Optional_): array: List of light entities which should be set in XY.
 * **lights_brightness** (_Optional_): array: List of light entities which should only have brightness adjusted.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Switch configuration variables:
 * **name** (_Optional_): The name to use when displaying this switch.
 * **lights_ct** (_Optional_): array: List of light entities which should be set in mireds.
 * **lights_rgb** (_Optional_): array: List of light entities which should be set in RGB.
-* **lights_rgbw** (_Optional_): array: List of light entities which should be set in RGBW.
+* **lights_rgbw** (_Optional_): array: List of light entities which should be set in RGBW. This is useful for RGBW LED such as SK6812.
 * **lights_xy** (_Optional_): array: List of light entities which should be set in XY.
 * **lights_brightness** (_Optional_): array: List of light entities which should only have brightness adjusted.
 

--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -27,7 +27,6 @@ Technical notes: I had to make a lot of assumptions when writing this app
         lights to 2700K (warm white) until your hub goes into Night mode
 """
 
-import asyncio
 import bisect
 from datetime import timedelta
 
@@ -56,6 +55,7 @@ from homeassistant.util.color import (
     color_RGB_to_xy,
     color_temperature_to_rgb,
     color_xy_to_hs,
+    color_rgb_to_rgbw,
 )
 
 DOMAIN = "circadian_lighting"
@@ -157,6 +157,7 @@ class CircadianLighting:
         self._percent = await self.async_calc_percent()
         self._colortemp = await self.async_calc_colortemp()
         self._rgb_color = await self.async_calc_rgb()
+        self._rgbw_color = await self.async_calc_rgbw()
         self._xy_color = await self.async_calc_xy()
 
         if self._manual_sunrise is not None:
@@ -304,6 +305,10 @@ class CircadianLighting:
     async def async_calc_rgb(self):
         return await self.hass.async_add_executor_job(color_temperature_to_rgb, self._colortemp)
 
+    async def async_calc_rgbw(self):
+        rgb = await self.async_calc_rgb()
+        return await self.hass.async_add_executor_job(color_rgb_to_rgbw, *rgb)
+
     async def async_calc_xy(self):
         rgb = await self.async_calc_rgb()
         return await self.hass.async_add_executor_job(color_RGB_to_xy, *rgb)
@@ -317,6 +322,7 @@ class CircadianLighting:
         self._percent = await self.async_calc_percent()
         self._colortemp = await self.async_calc_colortemp()
         self._rgb_color = await self.async_calc_rgb()
+        self._rgbw_color = await self.async_calc_rgbw()
         self._xy_color = await self.async_calc_xy()
         self._hs_color = await self.async_calc_hs()
         async_dispatcher_send(self.hass, CIRCADIAN_LIGHTING_UPDATE_TOPIC)

--- a/custom_components/circadian_lighting/__init__.py
+++ b/custom_components/circadian_lighting/__init__.py
@@ -307,7 +307,7 @@ class CircadianLighting:
 
     async def async_calc_rgbw(self):
         rgb = await self.async_calc_rgb()
-        return await self.hass.async_add_executor_job(color_rgb_to_rgbw, *rgb)
+        return rgb + tuple([0])
 
     async def async_calc_xy(self):
         rgb = await self.async_calc_rgb()

--- a/custom_components/circadian_lighting/sensor.py
+++ b/custom_components/circadian_lighting/sensor.py
@@ -79,6 +79,7 @@ class CircadianSensor(Entity):
         return {
             "colortemp": self._circadian_lighting._colortemp,
             "rgb_color": self._circadian_lighting._rgb_color,
+            "rgbw_color": self._circadian_lighting._rgbw_color,
             "xy_color": self._circadian_lighting._xy_color,
         }
 

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -303,7 +303,7 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         return color_temperature_to_rgb(self._color_temperature())
 
     def _calc_rgbw(self):
-        return color_rgb_to_rgbw(*self._calc_rgb())
+        return self._calc_rgb() + tuple([0])
 
     def _calc_xy(self):
         return color_RGB_to_xy(*self._calc_rgb())


### PR DESCRIPTION
When adding a RGBW LED strip such as SK6812, circadian lighting tries to set the temperature using either RGB, XY or CT modes. Those modes result in a translation from the specified values to RGBW values. When translated, the resulted value enables the cold white LED which results in a pink light instead of a warm white.
This pull request introduces a new mode -RGBW- where it calculates the values from RGB values after disabling the white LED. That results in a pure white colour when max RGB values are set because the chip can interpret those values correctly and a warm white colour after sunset.

The following picture is how it looked before modifications raised in this pull request:

![IMG_8806](https://github.com/claytonjn/hass-circadian_lighting/assets/5686018/886bbb0c-4cf9-46e2-8664-1634a1e9c5f7)

The following 2 pictures are after the modifications. The white colour is the result of before sunset time and the warm white is when the sun at lowest. All pictures are obtained with `min_brightness` set to `60`

![IMG_8807](https://github.com/claytonjn/hass-circadian_lighting/assets/5686018/41a0c8b9-3695-4a3f-9b72-2a45db905e4a)
![IMG_8808](https://github.com/claytonjn/hass-circadian_lighting/assets/5686018/bb9a9555-415a-4696-9369-e977b512b8be)

The switch setting looks like the following
```
switch:
  - platform: circadian_lighting
    name: Bedroom circadian lighting
    lights_ct:
      - light.bedroom_ceiling_lights_2
    lights_rgbw:
      - light.bed_backlight_left
      - light.bed_backlight_right
    min_brightness: 60
```
The settings of circadian lighting component look like the following:
```
circadian_lighting:
  sunrise_time: "04:30:00"
  sunset_time: "20:30:00"
```