### PR TITLE
Updated to fix async_track_state_change to async_track_state_change_event to conform with HA 2025.5

### DIFF
--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
@@ -357,7 +357,7 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
 
             light_type = self._lights_types[light]
             if light_type == "ct":
-                service_data[ATTR_COLOR_TEMP] = int(self._calc_ct())
+                service_data[ATTR_COLOR_TEMP_KELVIN] = int(self._calc_ct())
             elif light_type == "rgb":
                 r, g, b = self._calc_rgb()
                 service_data[ATTR_RGB_COLOR] = (int(r), int(g), int(b))

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -234,12 +234,12 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         async_track_state_change_event(
             self.hass, self._lights, self._light_state_changed
         )
-        track_kwargs = dict(hass=self.hass, action=self._state_changed)
+        track_kwargs = dict(hass=self.hass, action=self._light_state_changed)
         if self._sleep_entity is not None:
             sleep_kwargs = dict(track_kwargs, entity_ids=self._sleep_entity)
             async_track_state_change(**sleep_kwargs, to_state=self._sleep_state)
             async_track_state_change(**sleep_kwargs, from_state=self._sleep_state)
-
+        
         if self._disable_entity is not None:
             async_track_state_change(
                 **track_kwargs,

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -231,7 +231,7 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         )
 
         # Add listeners
-        async_track_state_change(
+        async_track_state_change_event(
             self.hass, self._lights, self._light_state_changed, to_state="on"
         )
         track_kwargs = dict(hass=self.hass, action=self._state_changed)

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -378,10 +378,17 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         if tasks:
             await asyncio.wait(tasks)
 
-    async def _light_state_changed(self, entity_id, from_state, to_state):
-        assert to_state.state == "on"
-        if from_state is None or from_state.state != "on":
-            _LOGGER.debug(_difference_between_states(from_state, to_state))
+async def _light_state_changed(self, event):
+    # Extract the entity_id, old_state, and new_state from the event data
+    entity_id = event.data.get("entity_id")
+    old_state = event.data.get("old_state")
+    new_state = event.data.get("new_state")
+
+    # Ensure the new state is "on"
+    if new_state and new_state.state == "on":
+        # Check if the old state was not "on" or was None
+        if old_state is None or old_state.state != "on":
+            _LOGGER.debug(_difference_between_states(old_state, new_state))
             await self._force_update_switch(lights=[entity_id])
 
     async def _state_changed(self, entity_id, from_state, to_state):

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -232,7 +232,7 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
 
         # Add listeners
         async_track_state_change_event(
-            self.hass, self._lights, self._light_state_changed, to_state="on"
+            self.hass, self._lights, self._light_state_changed
         )
         track_kwargs = dict(hass=self.hass, action=self._state_changed)
         if self._sleep_entity is not None:

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import slugify
 from homeassistant.util.color import (

--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -321,6 +321,23 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         self._brightness = self._calc_brightness()
         await self._adjust_lights(lights or self._lights, transition)
 
+    async def _light_state_changed(self, event):
+        """Handle light state changes."""
+        entity_id = event.data.get("entity_id")
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+
+        # Ensure the new state is "on"
+        if new_state and new_state.state == "on":
+            # Check if the old state was not "on" or was None
+            if old_state is None or old_state.state != "on":
+                _LOGGER.debug(
+                    "Light state changed: %s -> %s",
+                    old_state and old_state.state,
+                    new_state.state,
+                )
+                await self._force_update_switch(lights=[entity_id])
+                
     async def _force_update_switch(self, lights=None):
         return await self._update_switch(
             lights, transition=self._initial_transition, force=True


### PR DESCRIPTION
Just went through and did my best to maintain functionality while changing the async_track_state_change to async_track_state_change_event. Tested and working in my current HA / HACS install. Also updates ATTR_COLOR_TEMP to ATTR_COLOR_TEMP_KELVIN.

Home Assistant
Core 2025.1.3
Supervisor 2024.12.3
Operating System 14.1
Frontend 20250109.0

HACS
Integration version: | 2.0.3
Frontend version: | 20240903140523