### PR TITLE
Fix AssertionError on light state change events

### DIFF
--- a/custom_components/circadian_lighting/switch.py
+++ b/custom_components/circadian_lighting/switch.py
@@ -381,8 +381,10 @@ class CircadianSwitch(SwitchEntity, RestoreEntity):
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
 
-        assert new_state and new_state.state == "on"
-        if old_state is None or old_state.state != "on":
+        light_went_on = (old_state is None or old_state.state != "on") and (
+            new_state and new_state.state == "on"
+        )
+        if light_went_on:
             _LOGGER.debug(_difference_between_states(old_state, new_state))
             await self._force_update_switch(lights=[entity_id])
 


### PR DESCRIPTION
Whenever a light turns off, I see this in my HomeAssisstant logs:

    Error doing job: Task exception was never retrieved (None)
    Traceback (most recent call last):
    File "/config/custom_components/circadian_lighting/switch.py", line 384,
    in _light_state_changed
    assert new_state and new_state.state == "on"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError`

This is caused by an `assert` in the `_light_state_changed` function.

I've refactored `_light_state_change` to remove the `assert` while while keeping the existing function behavior.

When #258 replaced `async_track_state_change` with `async_track_state_change_event` due to upstream changes, there was a change in the upstream function signature.

Previously, `async_track_state_change` took a `state` argument, so events were only triggered when a light's state was `on`, so the assertion in `_light_state_changed` was probably unneeded still, but fine.

Now, `async_track_state_change_event` sends every event to the `_light_state_changed` callback. So when the light state changes to "off" or "unavailable", this assertion throws an exception.

My refactor determines if the light has turned on and triggers a forced update if so. This is the same logic as before my change, but without an assertion.

Fixes: #262