### PR TITLE
Changes to use new get_astral_observer

### DIFF
--- a/custom_components/circadian_lighting/manifest.json
+++ b/custom_components/circadian_lighting/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/claytonjn/hass-circadian_lighting/issues",
   "requirements": [],
-  "version": "2.1.6-beta"
+  "version": "2.1.6"
 }


### PR DESCRIPTION
Following upcoming deprecation of sun.get_astral_location, have reworked to make use of sun.get_astral_observer instead - works in my local instance, and should deal with [issue 271](https://github.com/claytonjn/hass-circadian_lighting/issues/271)